### PR TITLE
fix error 'matrix is undefined' for github actions

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -22,5 +22,6 @@
   "include_requirements_files": "y/N",
   "publish_to_pypi": "y/N",
   "__package_slug": "{{ cookiecutter.package_name.lower().replace(' ', '_').replace('-', '_') }}",
-  "__python_short_version": "{{ cookiecutter.python_version.split('.')[:2]|join('.') }}"
+  "__python_short_version": "{{ cookiecutter.python_version.split('.')[:2]|join('.') }}",
+  "_copy_without_render": [".github/*"]
 }


### PR DESCRIPTION
When trying to create project with github actions, we get this error

```
Unable to create file '.github/workflows/pytest.yaml'
Error message: 'matrix' is undefined
Context: {
```
Disabling render for `.github/*` resolves issue