### PR TITLE
Fix pypi workflow on private repos, fix alembic migration check

### DIFF
--- a/{{cookiecutter.__package_slug}}/.github/workflows/pypi.yaml
+++ b/{{cookiecutter.__package_slug}}/.github/workflows/pypi.yaml
@@ -19,6 +19,7 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6

--- a/{{cookiecutter.__package_slug}}/makefile
+++ b/{{cookiecutter.__package_slug}}/makefile
@@ -180,6 +180,9 @@ create_migration:
 
 .PHONY: check_ungenerated_migrations
 check_ungenerated_migrations:
-	$(UV) run alembic check
+	rm -f $(MIGRATION_DATABASE)
+	DATABASE_URL=sqlite:///$(MIGRATION_DATABASE) $(UV) run alembic upgrade head
+	DATABASE_URL=sqlite:///$(MIGRATION_DATABASE) $(UV) run alembic check
+	rm -f $(MIGRATION_DATABASE)
 
 {% endif %}


### PR DESCRIPTION
- pypi workflow only had id-token:write; declaring any permissions key drops all others to none, so checkout failed with 'repository not found' on private repos. Added contents:read to restore checkout access.

- check_ungenerated_migrations ran alembic check against whatever database DATABASE_URL pointed to. With some use cases there may be problems with the database in CI that results in alembic reporting 'Target database is not up to date'. Updated the target to create a fresh temp DB, run upgrade head, then check, then clean up — matching the create_migration pattern.